### PR TITLE
fix: Resolve Qt WebEngine rendering issues with custom URL scheme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,8 +69,8 @@ Contributions are welcome! Please see the CONTRIBUTING.md, COMMIT_MESSAGE.md, an
 
 - [ ] Fix database scraper (there still seems to be an issue with the function `fetch_active_period`). For now, it is
   commented out, but fixing it would improve performance when updating the database.
-- [ ] Switch the graph rendering for the table; it's kind of bad. (Qt web seems to be broken on my system, so I can't
-  test it. It now opens a browser tab instead.)
+- [x] Switch the graph rendering for the table; it's kind of bad. (Qt web seems to be broken on my system, so I can't
+  test it. It now opens a browser tab instead.). Fixed all credits go to => [link](https://stackoverflow.com/questions/39184615/qwebengineview-cannot-load-large-svg-html-using-sethtml)
 - [ ] Fix filter rules
 - [ ] There is currently no protection against race conditions (The watch list load has to be manually triggered).
 - [ ] TODO Split the Requirements.txt into separate files (This will make the installation of the ui Simpler as it does

--- a/src/ui/appDemoAsync.py
+++ b/src/ui/appDemoAsync.py
@@ -1,5 +1,6 @@
 import html
 import json
+import os
 import sys
 import asyncio
 import requests
@@ -9,10 +10,11 @@ from PyQt6.QtWidgets import (
     QComboBox, QPushButton, QHBoxLayout, QLineEdit, QMenuBar, QMenu
 )
 from PyQt6.QtCore import Qt
-from qasync import QEventLoop, asyncSlot
+from qasync import QEventLoop, asyncSlot, QtGui
 from src.logging.logging_config import logger
 import src.os_calls.basic_os_calls as os_calls
-from src.ui.PlotWindow import PlotWindow, has_redner_failed, open_in_browser
+from src.os_calls.basic_os_calls import get_root_path
+from src.ui.PlotWindow import PlotWindow, has_render_failed, open_in_browser
 
 
 # todo implement a loading bar
@@ -164,6 +166,8 @@ class AppDemo(QWidget):
 
         layout.setMenuBar(menu_bar)
         self.setLayout(layout)
+
+
 
     def add_filter_row(self):
         """
@@ -547,7 +551,7 @@ class AppDemo(QWidget):
         store_html(fig_html)
 
         # Check if Qt rendering has previously failed
-        if has_redner_failed():
+        if has_render_failed():
             open_in_browser(fig_html, row["symbol"])
             return
 
@@ -560,7 +564,7 @@ class AppDemo(QWidget):
         plot_window.show()
         self.plot_windows.append(plot_window)  # Keep a reference
 
-        if not has_redner_failed():
+        if not has_render_failed():
             if not QApplication.instance():
                 app.exec()
 


### PR DESCRIPTION
- Implemented a workaround to handle large HTML content rendering in QWebEngineView.
- Added a custom URL scheme handler to load HTML content efficiently.
- Ensured the application falls back to browser rendering if Qt fails to render.
- Included credits for the original workaround author from Stack Overflow.

link: https://stackoverflow.com/questions/39184615/qwebengineview-cannot-load-large-svg-html-using-sethtml